### PR TITLE
Added input parser for `icaopt` in `beamica`

### DIFF
--- a/beamica.m
+++ b/beamica.m
@@ -82,7 +82,7 @@ X = S*X;
 nP = length(P);
 P =  permute(cat(3,P{:}),[3 2 1]);
 
-fprintf('Running Beamica for %i iterations.\n',max_iter);
+fprintf('Running Beamica for %i iterations. Using %d splits\n',max_iter, numsplits);
 for i=1:numsplits
     ranges{i} = 1+floor((i-1)*N/numsplits) : min(N,floor(i*N/numsplits)); end
 if usegpu    

--- a/relica.m
+++ b/relica.m
@@ -166,7 +166,23 @@ if isstruct(EEG)
             switch algo
                 case 'beamica'
                     if i==1; nrun = 1500; else; nrun = 1200; end % ensure real ICA is good
-                    [Wf,Sf] = beamica(in,{},eye(size(in,1)),pinv(sqrtm(cov(in'))),mean(in,2),nrun,0.5,0.5,false,true,true,1);
+                    % Parse beamica opts
+                    p = inputParser;
+                    addOptional(p, 'lrate', 0.5, @(x) isnumeric());
+                    addOptional(p, 'tradeoff', 0.5, @(x) isnumeric(x) && (x >= 0) && (x <= 1));
+                    addOptional(p, 'verbose', false);
+                    addOptional(p, 'usegpu', true);
+                    addOptional(p, 'convergence_check', false);
+                    addOptional(p, 'numsplits', 1);
+                    parse(p, g.icaopt{:});
+                    lrate = p.Results.lrate;
+                    tradeoff = p.Results.tradeoff;
+                    verbose = p.Results.verbose;
+                    usegpu = p.Results.usegpu;
+                    convergence_check = p.Results.convergence_check;
+                    numsplits = p.Results.numsplits;
+                    % Feed beamica with the parsed opts
+                    [Wf,Sf] = beamica(in,{},eye(size(in,1)),pinv(sqrtm(cov(in'))),mean(in,2),nrun,lrate,tradeoff,verbose,usegpu,convergence_check,numsplits);
                     W_ = Wf * Sf;
                     A_ = pinv(W_);
                     


### PR DESCRIPTION
Hi all,

I was having troubles running relica on big datasets, I saw `beamica` could be run by splitting the dataset to save memory but there was no way of setting this option from the relica script. So I added an input parser for `beamica` options that uses the already present `icaopt` in the `relica.m` script.

Cheers,
+Enea 